### PR TITLE
📝 docs: update image source to use site.baseurl

### DIFF
--- a/docs/pages/index.md
+++ b/docs/pages/index.md
@@ -25,7 +25,7 @@ settings, streamlined workflows, and simplified maintenance across projects.
 
 <div align="center">
   <img
-    src="./assets/images/banner-standard.svg"
+    src="{{ site.baseurl }}/assets/images/banner-standard.svg"
     style="border-radius: 10px"
     alt="project banner"
   />


### PR DESCRIPTION
## 🎯 Purpose

Change the image source for the project banner to utilize the `site.baseurl` variable. This improves the reliability of the documentation display across different environments.

## 💡 Notes

No breaking changes introduced.